### PR TITLE
Error getting updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 # Project exclude paths
 /target/
 /src/main/resources/config.properties
-/src/main/java/com/itmo/bot/BotConfig.class
+/src/main/java/com/itmo/bot/BotConfig.java

--- a/src/main/java/com/itmo/bot/BootstrapClass.java
+++ b/src/main/java/com/itmo/bot/BootstrapClass.java
@@ -12,25 +12,8 @@ import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
 public class BootstrapClass {
 
     public static void main(String[] args) {
-
         // initializing the API
         ApiContextInitializer.init();
         ConfigurableApplicationContext context = SpringApplication.run(BootstrapClass.class, args);
-
-        // creating the Telegram API object
-        TelegramBotsApi telegramBotsApi = new TelegramBotsApi();
-
-        try {
-            // then register the bot
-//            new TelegramBotsApi()
-//                    .registerBot(SpringApplication.run(BootstrapClass.class, args)
-//                            .getBean(Bot.class));
-
-            Bot bot = context.getBean(Bot.class);
-            System.out.println("HASH FROM MAIN: " + bot.hashCode());
-            telegramBotsApi.registerBot(bot);
-        } catch (TelegramApiException e) {
-            e.printStackTrace();
-        }
     }
 }


### PR DESCRIPTION
You don't have to call "registerBot"!

1. Debug org.telegram.telegrambots.meta.api.methods.updates.GetUpdates.deserializeResponse(GetUpdates.java:118)

```
        try {
            ApiResponse<ArrayList<Update>> result = (ApiResponse)OBJECT_MAPPER.readValue(answer, new TypeReference<ApiResponse<ArrayList<Update>>>() {
            });
            if (result.getOk()) {
                return (ArrayList)result.getResult();
            } else {
                throw new TelegramApiRequestException("Error getting updates", result);
            }
        } catch (IOException var3) {
            throw new TelegramApiRequestException("Unable to deserialize response", var3);
        }
```

result is **{"ok":false,"error_code":409,"description":"Conflict: terminated by other getUpdates request; make sure that only one bot instance is running"}**!

2. Take a look on TelegramBotInitializer class:
This class can get bean from context and register it automatically!

So, you can just do this:
```
    public static void main(String[] args) {
        // initializing the API
        ApiContextInitializer.init();
        ConfigurableApplicationContext context = SpringApplication.run(BootstrapClass.class, args);
    }
```